### PR TITLE
Fix auth check loading state

### DIFF
--- a/src/hooks/use-auth-check.ts
+++ b/src/hooks/use-auth-check.ts
@@ -42,6 +42,8 @@ export function useAuthCheck({
       
       // 로그인 페이지로 리다이렉션
       router.push(redirectTo);
+      setIsAuthenticated(false);
+      setIsLoading(false);
     } else {
       // 인증된 경우
       setIsAuthenticated(true);


### PR DESCRIPTION
## Summary
- fix authentication hook to clear loading state when redirecting

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414821e5b08329984cada02c2a86db